### PR TITLE
Add localstack-token secret to modern Gradle workflows

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,6 +7,8 @@ on:
         required: true
       nexus-password:
         required: true
+      localstack-token:
+        required: true
     inputs:
       runner:
         description: "The runner to use"
@@ -47,6 +49,7 @@ jobs:
     env:
       ORG_GRADLE_PROJECT_nexusUsername: ${{ secrets.nexus-username }}
       ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.nexus-password }}
+      ORG_GRADLE_PROJECT_localstackToken: ${{ secrets.localstack-token }}
       AWS_REGION: ${{ inputs.region }}
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
         required: true
       actions-access-token:
         required: true
+      localstack-token:
+        required: true
     inputs:
       dispatch_event:
         type: boolean
@@ -71,6 +73,7 @@ jobs:
     env:
       ORG_GRADLE_PROJECT_nexusUsername: ${{ secrets.nexus-username }}
       ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.nexus-password }}
+      ORG_GRADLE_PROJECT_localstackToken: ${{ secrets.localstack-token }}
       AWS_REGION: eu-west-1
     steps:
       - name: "Getting repository name"

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -13,6 +13,8 @@ on:
         required: true
       nvd-api-key:
         required: false
+      localstack-token:
+        required: true
     inputs:
       cache-version:
         description: 'A cache version passed from the caller workflow'
@@ -54,6 +56,7 @@ jobs:
     env:
       ORG_GRADLE_PROJECT_nexusUsername: ${{ secrets.nexus-username }}
       ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.nexus-password }}
+      ORG_GRADLE_PROJECT_localstackToken: ${{ secrets.localstack-token }}
       ORG_GRADLE_PROJECT_sonarqubeHostUrl: ${{ secrets.sonarqube-host }}
       ORG_GRADLE_PROJECT_sonarqubeLoginToken: ${{ secrets.sonarqube-token }}
       ORG_GRADLE_PROJECT_nvdApiKey: ${{ secrets.nvd-api-key }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.idea/
 *.iml
+
+.sfdx/


### PR DESCRIPTION
## Summary
- Add required `localstack-token` secret declaration to `pull-request.yml`, `release.yml`, and `sonarqube.yml`
- Set `ORG_GRADLE_PROJECT_localstackToken` env var from the secret in all three workflows
- Update `.gitignore` to exclude `.sfdx/` directory

## Test plan
- [ ] Verify consuming repos pass `localstack-token` secret when calling these workflows
- [ ] Confirm Gradle builds can access the `localstackToken` project property

🤖 Generated with [Claude Code](https://claude.com/claude-code)