### PR TITLE
Add restore-keys fallback for dependency check cache

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -108,6 +108,9 @@ jobs:
         with:
           # Using date in cache key as OWASP database may change, without the gradle file changing
           key: dependency-check-data-${{ runner.os }}-${{ steps.get-current-date.outputs.date }}-${{ hashFiles('**/build.gradle') }}
+          restore-keys: |
+            dependency-check-data-${{ runner.os }}-${{ steps.get-current-date.outputs.date }}-
+            dependency-check-data-${{ runner.os }}-
           path: ~/.gradle/dependency-check-data
 
       - name: 'Analyze dependencies'


### PR DESCRIPTION
## Summary
- Adds `restore-keys` to the dependency check cache restore step in `sonarqube.yml`
- Without this, a cache miss on the exact daily key forces a full NVD database download (~35+ minutes), often causing the job to time out
- With fallback prefixes, a previous day's cache is restored and only incremental NVD updates are fetched (seconds)

## Test plan
- [x] Trigger a `SonarQube for Release` workflow and verify the cache restore step falls back to a previous key when the exact key misses
- [x] Confirm `dependencyCheckAnalyze` completes in minutes instead of 35+

🤖 Generated with [Claude Code](https://claude.com/claude-code)